### PR TITLE
Potential fix for code scanning alert no. 6: Unbounded write

### DIFF
--- a/linux/command-proc.cpp
+++ b/linux/command-proc.cpp
@@ -210,8 +210,12 @@ void HVCPCommandProc::command_loop(){
           recv_string(filename, len);
           std::cout << "filename: " << filename << std::endl;
           if(path[strlen(path) - 1] == '/'){
-            strcat(path, filename);
-            std::cout << "remote path: " << path << std::endl;
+            if(strlen(path) + strlen(filename) < sizeof(path)){
+              strncat(path, filename, sizeof(path) - strlen(path) - 1);
+              std::cout << "remote path: " << path << std::endl;
+            } else {
+              throw ERR_INVALID_REMOTE_PATH;
+            }
           }
           send_result(HVCP_CMD_RESULT_OK, nullptr, 0);
         }


### PR DESCRIPTION
Potential fix for [https://github.com/YaSuenag/hvcp/security/code-scanning/6](https://github.com/YaSuenag/hvcp/security/code-scanning/6)

To fix the issue, we need to replace the unsafe `strcat` function with a safer alternative that performs bounds checking. Specifically, we can use `strncat`, which allows us to specify the maximum number of characters to append to the destination buffer. Additionally, we need to ensure that the combined length of `path` and `filename` does not exceed the size of `path`.

Steps to fix:
1. Replace `strcat` with `strncat`.
2. Add a check to ensure that the combined length of `path` and `filename` is less than the size of `path` before performing the concatenation.
3. Define the size of `path` explicitly if it is not already defined.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
